### PR TITLE
Fix: users repo activate missing fields

### DIFF
--- a/pkg/usecases/users/repo_sqlx.go
+++ b/pkg/usecases/users/repo_sqlx.go
@@ -285,11 +285,11 @@ FOR UPDATE
 	consumeQ := `
 UPDATE
 	user_registration_requests
-SET consumed=NOW()
+SET consumed=$2
 WHERE
 	token=$1
 `
-	if _, err := tx.Exec(consumeQ, token); err != nil {
+	if _, err := tx.Exec(consumeQ, token, now); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
 			r.ins.L.Err(rbErr, "rollback failed")
 		}
@@ -308,10 +308,10 @@ VALUES(
 	$1
 	,$2
 	,$3
-	,NOW()
+	,$4
 )
 `
-	if _, err := tx.Exec(createUserQ, id.ToUUID(), rq.email, rq.password); err != nil {
+	if _, err := tx.Exec(createUserQ, id.ToUUID(), rq.email, rq.password, now); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
 			r.ins.L.Err(rbErr, "rollback failed")
 		}
@@ -327,7 +327,9 @@ VALUES(
 	}
 
 	return &User{
-		Email: rq.email,
+		ID:      id,
+		Email:   rq.email,
+		Created: now,
 	}, nil
 }
 

--- a/pkg/usecases/users/repo_sqlx_test.go
+++ b/pkg/usecases/users/repo_sqlx_test.go
@@ -2,8 +2,11 @@ package users
 
 import (
 	"testing"
+	"time"
 
 	hfwtest "github.com/dhontecillas/hfw/testing"
+
+	"github.com/dhontecillas/hfw/pkg/ids"
 )
 
 func Test_RepoSQLX_HappyPath(t *testing.T) {
@@ -33,6 +36,18 @@ func Test_RepoSQLX_HappyPath(t *testing.T) {
 
 	if u.Email != email {
 		t.Errorf("email, want: %s, got: %s", email, u.Email)
+		return
+	}
+
+	var emptyID ids.ID
+	if u.ID == emptyID {
+		t.Errorf("empty user id")
+		return
+	}
+
+	var zeroTime time.Time
+	if u.Created == zeroTime {
+		t.Errorf("empty created time")
 		return
 	}
 


### PR DESCRIPTION
The `User` entity returned from the users use case is missing the creation (activation) date and the `ID` of the created user.  Also fixed a broken build for the bundler example executable when checking the tests.
