### PR TITLE
add config option to use mailgun with eu servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # **HFW**: Handy FrameWork
-![Coverage](https://img.shields.io/badge/Coverage-22.9%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-22.8%25-red)
 
 Go framework for API and Web development.
 

--- a/pkg/mailer/mailgun.go
+++ b/pkg/mailer/mailgun.go
@@ -12,8 +12,9 @@ import (
 
 // MailgunConfig has the parameters to use the Mailgun service
 type MailgunConfig struct {
-	Domain string
-	Key    string
+	Domain      string
+	Key         string
+	UseEUServer bool
 }
 
 // MailgunMailer implements the Mailer interface to send emails using Mailgun service
@@ -29,8 +30,12 @@ func NewMailgunMailer(conf MailgunConfig) (*MailgunMailer, error) {
 	if len(conf.Domain) == 0 {
 		return nil, fmt.Errorf("missing Mailgun Domain")
 	}
+	client := mailgun.NewMailgun(conf.Domain, conf.Key)
+	if conf.UseEUServer {
+		client.SetAPIBase(mailgun.APIBaseEU)
+	}
 	return &MailgunMailer{
-		client: mailgun.NewMailgun(conf.Domain, conf.Key),
+		client: client,
 	}, nil
 }
 


### PR DESCRIPTION
The URL for mailgun accounts in the EU should be different. Add a boolean to the mailgun config to check what server it should hit.