### PR TITLE
Move sendgrid config outside of mailer package

### DIFF
--- a/pkg/config/mailer_sengrid.go
+++ b/pkg/config/mailer_sengrid.go
@@ -9,31 +9,38 @@ import (
 	"github.com/spf13/viper"
 )
 
-const confKeySendgridKey string = "sendgrid.key"
+const (
+	confKeySendgridKey         string = "sendgrid.key"
+	confKeySendgridSenderEmail string = "sendgrid.senderemail"
+	confKeySendgridSenderName  string = "sendgrid.sendername"
+)
+
+// SendGridConfig has the parameters to use the SendGrid service
+type SendGridConfig struct {
+	Key string
+}
 
 // configSendGrid fills a SendGridConfig struct from viper parameters
-func configSendGrid(confPrefix string) (mailer.SendGridConfig, error) {
+func configSendGrid(confPrefix string) (SendGridConfig, error) {
 	if !viper.IsSet(confPrefix + confKeySendgridKey) {
-		return mailer.SendGridConfig{}, fmt.Errorf("missing sendgrid Key: %s",
+		return SendGridConfig{}, fmt.Errorf("missing sendgrid Key: %s",
 			confPrefix+confKeySendgridKey)
 	}
-	val := viper.GetString(confPrefix + confKeySendgridKey)
-	return mailer.SendGridConfig{
-		Key: val,
+	key := viper.GetString(confPrefix + confKeySendgridKey)
+
+	return SendGridConfig{
+		Key: key,
 	}, nil
 }
 
 func newSendgridMailer(ins *obs.Insighter, confPrefix string,
 	from string, name string) (mailer.Mailer, error) {
-
 	conf, err := configSendGrid(confPrefix)
 	if err != nil {
 		return nil, err
 	}
-	conf.FromAddress = from
-	conf.FromName = name
 	ins.L.Info(fmt.Sprintf("new sendgrid config %#v", conf))
-	m, err := mailer.NewSendGridMailer(conf)
+	m, err := mailer.NewSendGridMailer(conf.Key, from, name)
 	ins.L.Info(fmt.Sprintf("created mailer: %#v", m))
 	return m, err
 }

--- a/pkg/mailer/mailgun.go
+++ b/pkg/mailer/mailgun.go
@@ -10,32 +10,39 @@ import (
 	"github.com/mailgun/mailgun-go/v4"
 )
 
-// MailgunConfig has the parameters to use the Mailgun service
-type MailgunConfig struct {
-	Domain      string
-	Key         string
-	UseEUServer bool
-}
-
 // MailgunMailer implements the Mailer interface to send emails using Mailgun service
 type MailgunMailer struct {
 	client *mailgun.MailgunImpl
+
+	senderEmail string
+	senderName  string
 }
 
 // NewMailgunMailer creates a new Mailer to send emails through Mailgun
-func NewMailgunMailer(conf MailgunConfig) (*MailgunMailer, error) {
-	if len(conf.Key) == 0 {
-		return nil, fmt.Errorf("missing Mailgun Key")
-	}
-	if len(conf.Domain) == 0 {
+func NewMailgunMailer(domain string, key string, senderEmail string,
+	senderName string, useEUServer bool) (*MailgunMailer, error) {
+
+	if len(domain) == 0 {
 		return nil, fmt.Errorf("missing Mailgun Domain")
 	}
-	client := mailgun.NewMailgun(conf.Domain, conf.Key)
-	if conf.UseEUServer {
+	if len(key) == 0 {
+		return nil, fmt.Errorf("missing Mailgun Key")
+	}
+	if len(senderEmail) == 0 {
+		return nil, fmt.Errorf("missing Mailgun Sender Email Address")
+	}
+	if len(senderName) == 0 {
+		senderName = senderEmail
+	}
+
+	client := mailgun.NewMailgun(domain, key)
+	if useEUServer {
 		client.SetAPIBase(mailgun.APIBaseEU)
 	}
 	return &MailgunMailer{
-		client: client,
+		client:      client,
+		senderEmail: senderEmail,
+		senderName:  senderName,
 	}, nil
 }
 
@@ -57,5 +64,5 @@ func (m *MailgunMailer) Send(e Email) error {
 
 // Sender returns the default sender address and name
 func (m *MailgunMailer) Sender() (string, string) {
-	return "noreply@example.com", "No Reply"
+	return m.senderEmail, m.senderName
 }

--- a/pkg/mailer/sendgrid.go
+++ b/pkg/mailer/sendgrid.go
@@ -8,44 +8,40 @@ import (
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 
-// SendGridConfig has the parameters to use the SendGrid service
-type SendGridConfig struct {
-	Key         string
-	FromAddress string
-	FromName    string
-}
-
 // SendGridMailer implements the Mailer interface to send emails using SendGrid service
 type SendGridMailer struct {
-	client      *sendgrid.Client
-	FromAddress string
-	FromName    string
+	client *sendgrid.Client
+
+	fromAddress string
+	fromName    string
 }
 
 // NewSendGridMailer creates a new Mailer to send emails through SendGrid
-func NewSendGridMailer(conf SendGridConfig) (*SendGridMailer, error) {
-	if len(conf.Key) == 0 {
+func NewSendGridMailer(key, fromAddress, fromName string) (*SendGridMailer, error) {
+	if len(key) == 0 {
 		return nil, fmt.Errorf("missing SendGrid key")
 	}
-	if len(conf.FromAddress) == 0 {
+	if len(fromAddress) == 0 {
 		return nil, fmt.Errorf("missing from address")
 	}
-	name := conf.FromName
-	if len(name) == 0 {
-		name = conf.FromAddress
+	if len(fromName) == 0 {
+		fromName = fromAddress
 	}
 	return &SendGridMailer{
-		client:      sendgrid.NewSendClient(conf.Key),
-		FromAddress: conf.FromAddress,
-		FromName:    name,
+		client:      sendgrid.NewSendClient(key),
+		fromAddress: fromAddress,
+		fromName:    fromName,
 	}, nil
 }
 
 // Send sends an email through SendGrid
 func (m *SendGridMailer) Send(e Email) error {
+	// TODO: we can check that e.From user matches the
+	// configured sendgrid from sender, and emit a warning
+	// on mismatch
 	resp, err := m.client.Send(
 		mail.NewSingleEmail(
-			mail.NewEmail(m.FromName, m.FromAddress),
+			mail.NewEmail(m.fromName, m.fromAddress),
 			e.Subject,
 			mail.NewEmail(e.To.Name, e.To.Address),
 			e.Text,
@@ -60,5 +56,5 @@ func (m *SendGridMailer) Send(e Email) error {
 }
 
 func (m *SendGridMailer) Sender() (string, string) {
-	return m.FromAddress, m.FromName
+	return m.fromAddress, m.fromName
 }


### PR DESCRIPTION
- Remove the config struct for sendgrid from the mailer package, and change signature to construct a Sendgrid mailer.
- Provide mailgun sender email and name in contructor.